### PR TITLE
CSS Curseur pointe bouton & a:visited ne modifie pas couleur de liens.

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,3 +1,5 @@
 .current {
   color: green;
+}}
+  color: inherit;
 }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -1,5 +1,6 @@
 .current {
   color: green;
-}}
+}
+*{
   color: inherit;
 }

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -67,6 +67,7 @@ $card-padding: .7rem;
   text-decoration: none;
   background: transparent;
   padding: 5px;
+  cursor: pointer;
   border: 1px solid #ffffff !important;
   border-radius: 5px;
   display: inline-block;


### PR DESCRIPTION
Lorsqu'on survole un filtre, la souris se met en mode pointeur et lorsqu'on clique sur un lien, le lien conserve sa couleur d'origine.